### PR TITLE
Extend form helpers plus tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -100,7 +100,7 @@ gulp.task('js', function () {
 
 
 // JSHint:
-gulp.task('jshint', function() {
+gulp.task('jshint', ['js'], function() {
   gulp.src("dist/chocolatechip-" + pkg.version + ".js")
     // jshint and options:
     .pipe(jshint({
@@ -126,7 +126,7 @@ gulp.task('jshint', function() {
 });
 
 // Create Tests:
-gulp.task('tests', function() {
+gulp.task('tests', ['jshint'], function() {
   gulp.src('src/tests/qunit/*')
     .pipe(gulp.dest('tests/qunit'));
 

--- a/src/chocolatechip/form.js
+++ b/src/chocolatechip/form.js
@@ -1,6 +1,60 @@
 (function(){
   "use strict";
-  $.extend($, {  
+  function getFormValues(rootNode) {
+    var result = [];
+    var currentNode = rootNode.firstChild;
+    while (currentNode) {
+      if (currentNode.nodeName.match(/INPUT|SELECT|TEXTAREA/i)) {
+        result.push({ name: currentNode.name, value: getFieldValue(currentNode)});
+      } else {
+        var subresult = getFormValues(currentNode);
+        result = result.concat(subresult);
+      }
+      currentNode = currentNode.nextSibling;
+    }
+    return result;
+  }
+  function getFieldValue(fieldNode) {
+    if (fieldNode.nodeName === 'INPUT') {
+      if (fieldNode.type.toLowerCase() === 'radio' || fieldNode.type.toLowerCase() === 'checkbox') {
+        if (fieldNode.checked) {
+          return fieldNode.value;
+        }
+      } else if (fieldNode.type.toLowerCase() === 'file' && fieldNode.files.length > 0) {
+        return fieldNode.files[0];
+      } else {
+        if (!fieldNode.type.toLowerCase().match(/button|reset|submit|image/i)) {
+          return fieldNode.value;
+        }
+      }
+    } else {
+      if (fieldNode.nodeName === 'TEXTAREA') {
+        return fieldNode.value;
+      } else {
+        if (fieldNode.nodeName === 'SELECT') {
+          return getSelectedOptionValue(fieldNode);
+        }
+      }
+    }
+    return '';
+  }
+  function getSelectedOptionValue(selectNode) {
+    var multiple = selectNode.multiple;
+    if (!multiple) {
+      return selectNode.value;
+    }
+    if (selectNode.selectedIndex > -1) {
+      var result = [];
+      $('option', selectNode).each(function(item) {
+        if (item.selected) {
+          result.push(item.value);
+        }
+      });
+      return result;
+    }
+  }
+
+  $.extend($, {
     // Convert form values into JSON object:
     form2JSON : function(rootNode, delimiter) {
       rootNode = typeof rootNode === 'string' ? $(rootNode)[0] : rootNode;
@@ -8,58 +62,7 @@
       var formValues = getFormValues(rootNode);
       var result = {};
       var arrays = {};
-      
-      function getFormValues(rootNode) {
-        var result = [];
-        var currentNode = rootNode.firstChild;
-        while (currentNode) {
-          if (currentNode.nodeName.match(/INPUT|SELECT|TEXTAREA/i)) {
-            result.push({ name: currentNode.name, value: getFieldValue(currentNode)});
-          } else {
-            var subresult = getFormValues(currentNode);
-            result = result.concat(subresult);
-          }
-          currentNode = currentNode.nextSibling;
-        }
-        return result;
-      }
-      function getFieldValue(fieldNode) {
-        if (fieldNode.nodeName === 'INPUT') {
-          if (fieldNode.type.toLowerCase() === 'radio' || fieldNode.type.toLowerCase() === 'checkbox') {
-            if (fieldNode.checked) {
-              return fieldNode.value;
-            }
-          } else {
-            if (!fieldNode.type.toLowerCase().match(/button|reset|submit|image/i)) {
-              return fieldNode.value;
-            }
-          }
-        } else {
-          if (fieldNode.nodeName === 'TEXTAREA') {
-            return fieldNode.value;
-          } else {
-            if (fieldNode.nodeName === 'SELECT') {
-              return getSelectedOptionValue(fieldNode);
-            }
-          }
-        }
-        return '';
-      }
-      function getSelectedOptionValue(selectNode) {
-        var multiple = selectNode.multiple;
-        if (!multiple) {
-          return selectNode.value;
-        }
-        if (selectNode.selectedIndex > -1) {
-          var result = [];
-          $('option', selectNode).each(function(item) {
-            if (item.selected) {
-              result.push(item.value);
-            }
-          });
-          return result;
-        }
-      }   
+
       formValues.each(function(item) {
         var value = item.value;
         if (value !== '') {
@@ -90,13 +93,13 @@
                 } else {
                   if (!arrays[arrName][arrIdx]) {
                     currResult[arrName].push({});
-                    arrays[arrName][arrIdx] = 
+                    arrays[arrName][arrIdx] =
                     currResult[arrName][currResult[arrName].length - 1];
                   }
                 }
                 currResult = arrays[arrName][arrIdx];
               } else {
-                if (j < nameParts.length - 1) { 
+                if (j < nameParts.length - 1) {
                   if (!currResult[namePart]) {
                     currResult[namePart] = {};
                   }
@@ -110,6 +113,18 @@
         }
       });
       return result;
+    },
+    // Convert form values into a FormData object:
+    form2FormData : function(rootNode) {
+      rootNode = typeof rootNode === 'string' ? $(rootNode)[0] : rootNode;
+      var formData = new FormData();
+      var formValues = getFormValues(rootNode);
+
+      formValues.each(function(item) {
+        if (item.value !== '')
+          formData.append(item.name, item.value);
+      });
+      return formData;
     }
   });
 })();

--- a/src/tests/chocolatechip/form-tests.html
+++ b/src/tests/chocolatechip/form-tests.html
@@ -1,0 +1,74 @@
+  <body>
+    <h1 id='qunit-header2'>QUnit ChocolateChipJS: Form</h1>
+    <div id="qunit"></div> <!-- QUnit fills this with results, etc -->
+    <div id='qunit-fixture'>
+      <!-- any HTML you want to be present in each test (will be reset for each test) -->
+      <form id="vanilla">
+        <label for="input1">Text: </label>
+        <input type="text" name="input1" value="blah" />
+        <br/>
+        <label for="input2">Checkbox: </label>
+        <input type="checkbox" name="input2" value="checked" checked="checked" />
+        <br/>
+        <label for="input3">Color: </label>
+        <input type="color" name="input3" value="#e59997" />
+        <br/>
+        <label for="input4">Date: </label>
+        <input type="date" name="input4" value="2014-11-12" />
+        <br/>
+        <label for="input5">Password: </label>
+        <input type="password" name="input5" value="abcdef" />
+        <br/>
+        <label for="input6">Hidden: </label>
+        <input type="hidden" name="input6" value="hidden" />
+        <br/>
+        <label for="input7">Month: </label>
+        <input type="month" name="input7" value="2014-11" />
+        <br/>
+        <label for="input8">Number: </label>
+        <input type="number" name="input8" value="6" />
+        <br/>
+        <label for="input9">Radio: </label>
+        <input type="radio" name="input9" value="radio" checked="checked" />
+        <br/>
+        <label for="input10">Time: </label>
+        <input type="time" name="input10" value="02:59" />
+        <br/>
+        <label for="input11">Button: </label>
+        <input type="button" name="input11" value="abcdef" />
+        <br/>
+        <label for="input12">Image: </label>
+        <input type="image" name="input12" height="20" width="20" alt="Image" src="" />
+        <br/>
+        <label for="input13">File: </label>
+        <input type="file" name="input13" value="abcdef" />
+        <br/>
+        <textarea name="textarea" rows="10" cols="50">Content</textarea>
+        <br/>
+        <label for="select">Select: </label>
+        <select name="select">
+          <option value="value1">Value 1</option>
+          <option value="value2" selected>Value 2</option>
+          <option value="value3">Value 3</option>
+        </select>
+        <input type="submit" name="submit">
+        <input type="reset" name="reset">
+      </form>
+
+      <form id="nested">
+        <label for="input1">Text: </label>
+        <input id="nestedinput1" type="text" name="input1" value="input1" />
+        <br/>
+        <label for="input2">Nested text: </label>
+        <input id="nestedinput2" type="text" name="nested.input2" value="input2" />
+        <br/>
+        <label for="input3">More nested text: </label>
+        <input id="nestedinput3" type="text" name="nested.input3" value="input3" />
+        <br/>
+        <label for="input4">Deep nested text: </label>
+        <input id="nestedinput4" type="text" name="deep.nested.input4" value="input4" />
+      </form>
+    </div>
+    <script src='form-tests.js'></script>
+  </body>
+</html>

--- a/src/tests/chocolatechip/form-tests.js
+++ b/src/tests/chocolatechip/form-tests.js
@@ -1,0 +1,40 @@
+module('Form Tests');
+
+// 1
+test('$.form2JSON input serialization', function() {
+  var form = $('#vanilla');
+  var serializedForm = $.form2JSON('#vanilla', '.');
+  equal(serializedForm.input1, form.children('[name=input1]').val(), 'Should have serialized text input');
+  equal(serializedForm.input2, form.children('[name=input2]').val(), 'Should have serialized checkbox input');
+  equal(serializedForm.input3, form.children('[name=input3]').val(), 'Should have serialized color input');
+  equal(serializedForm.input4, form.children('[name=input4]').val(), 'Should have serialized date input');
+  equal(serializedForm.input5, form.children('[name=input5]').val(), 'Should have serialized password input');
+  equal(serializedForm.input6, form.children('[name=input6]').val(), 'Should have serialized hidden input');
+  equal(serializedForm.input7, form.children('[name=input7]').val(), 'Should have serialized month input');
+  equal(serializedForm.input8, form.children('[name=input8]').val(), 'Should have serialized number input');
+  equal(serializedForm.input9, form.children('[name=input9]').val(), 'Should have serialized radio input');
+  equal(serializedForm.input10, form.children('[name=input10]').val(), 'Should have serialized time input');
+  equal(serializedForm.input11, undefined, 'Should not have serialized button input');
+  equal(serializedForm.input12, undefined, 'Should not have serialized image input');
+  equal(serializedForm.textarea, form.children('[name=textarea]').val(), 'Should have serialized textarea');
+  equal(serializedForm.select, form.children('[name=select]').val(), 'Should have serialized select');
+  equal(serializedForm.submit, undefined, 'Should not have serialized submit input');
+  equal(serializedForm.reset, undefined, 'Should not have serialized reset input');
+});
+
+// 2
+test('$.form2JSON nesting values by name and delimiter', function() {
+  var form = $('#nested');
+  var serializedForm = $.form2JSON('#nested', '.');
+  equal(serializedForm.input1, $('#nestedinput1').val(), 'Should have serialized input as root property');
+  equal(serializedForm.nested.input2, $('#nestedinput2').val(), 'Should have serialized input under nested property');
+  equal(serializedForm.nested.input3, $('#nestedinput3').val(), 'Should have serialized input under nested property as well');
+  equal(serializedForm.deep.nested.input4, $('#nestedinput4').val(), 'Should have serialized input under deep.nested property');
+});
+
+// 3
+test('$.form2FormData', function() {
+  var form = $('#vanilla');
+  var serializedForm = $.form2FormData('#vanilla');
+  equal(serializedForm.constructor, FormData, 'Should return a FormData object');
+});


### PR DESCRIPTION
Adds a new method `form2FormData` that returns a FormData object with all the inputs of a form added to it. This makes it easy to submit via AJAX, and will also properly handle file inputs (unlike form2JSON).

I added tests to cover the form helpers as well.

@sebmartin @pseudomuto @lemonmade 
